### PR TITLE
Drop raf dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const raf = require('raf');
+const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : setTimeout;
 
 module.exports = function(collection, iteratee, parts) {
   const collectionLen = collection.length;

--- a/package.json
+++ b/package.json
@@ -15,8 +15,5 @@
   "bugs": {
     "url": "https://github.com/yankouskia/loopasync/issues"
   },
-  "homepage": "https://github.com/yankouskia/loopasync#readme",
-  "dependencies": {
-    "raf": "*"
-  }
+  "homepage": "https://github.com/yankouskia/loopasync#readme"
 }


### PR DESCRIPTION
requestAnimationFrame is widely supported now: http://caniuse.com/#feat=requestanimationframe